### PR TITLE
Close parent window when exiting with Ctrl-D

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -251,7 +251,7 @@ class PythonConsole(BaseConsole):
 
     def _close(self):
         self.interpreter.exit()
-        self.close()
+        self.window().close()
 
     def _handle_ctrl_c(self):
         _id = threading.current_thread().ident


### PR DESCRIPTION
Hi,

when you embed the control into a parent window (e.g. QDialog) and allow ctrl+d to close the console, it will rather awkwardly only close the text edit which leaves a gray space inside the window.

This changes to always close the current window instead.