### PR TITLE
Change inuithread example to avoid spinning at 100% CPU

### DIFF
--- a/examples/inuithread.py
+++ b/examples/inuithread.py
@@ -17,6 +17,6 @@ if __name__ == '__main__':
     
     pyconsole_input_timer = QtCore.QTimer()
     pyconsole_input_timer.timeout.connect(console.repl_nonblock)
-    pyconsole_input_timer.start(0)    
+    pyconsole_input_timer.start(10)
 
     sys.exit(app.exec_())

--- a/examples/inuithread.py
+++ b/examples/inuithread.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #/usr/bin/python
 import sys
-import _phome
 
 from pyqtconsole.qt import QtCore
 from pyqtconsole.qt.QtWidgets import (QApplication)
@@ -10,13 +9,12 @@ from pyqtconsole.console import PythonConsole
 if __name__ == '__main__':
     from PyMca5.PyMca import PlotWindow
     app = QApplication([])
-    
+
     console = PythonConsole()
     console.push_local_ns('PlotWindow', PlotWindow)
     console.show()
-    
-    pyconsole_input_timer = QtCore.QTimer()
-    pyconsole_input_timer.timeout.connect(console.repl_nonblock)
-    pyconsole_input_timer.start(10)
+
+    console.stdin.write_event.connect(
+        console.repl_nonblock, QtCore.Qt.ConnectionType.QueuedConnection)
 
     sys.exit(app.exec_())


### PR DESCRIPTION
Hi,

the `inuithread.py` example spins at 100% CPU due to continuously polling `repl_nonblock`. This can be somewhat mitigated by increasing the timeout to e.g. 10ms, which is still unnoticibly small for most (non-super) humans.

However, after looking at the stream class, I realized it is already QObject based and we can therefore simply avoid polling altogether by connecting to the `write_event` signal, which is much nicer.

This also prevents the issue that the user had in #9 (and I had as well).

By the way, is there a reason for using this stream based text protocol, as opposed to say using signals directly to notify the interpreter? For example, replace:

```python
        self.stdin.write('EOF\n')
```

by

```python
        self.closed.emit()
```

etc...

and let the interpreter listen to these signals. It seems clearer and simpler to me, but I might not have considered all use-cases.

I would submit a patch, but I won't go through the effort if it is not compatible with some of your use cases.

Best, Thomas

Lovely package by the way, it works much nicer and faster than jupyter's qtconsole which has several problems.