### PR TITLE
Fixes

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -223,7 +223,8 @@ class BaseConsole(QTextEdit):
         self.stdin.write('EOF\n')
 
     def _close(self):
-        self.window().close()
+        if self.window().isVisible():
+            self.window().close()
 
     def _evaluate_buffer(self):
         _buffer = str(self.sender().parent().parent().toPlainText())

--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -82,7 +82,7 @@ class BaseConsole(QTextEdit):
         # Make sure that we can't move the cursor outside of the editing buffer
         # If outside buffer and no modifiers used move the cursor back into to
         # the buffer
-        if not event.modifiers() and not self._in_buffer():
+        if not event.modifiers() and self._cursor_offset() < 0:
             self._keep_cursor_in_buffer()
 
         # Call the TextEdit keyPressEvent for the events that are not
@@ -104,11 +104,9 @@ class BaseConsole(QTextEdit):
         return False
 
     def handle_backspace_key(self, event):
-        intercepted = False
+        intercepted = self._cursor_offset() < 1
 
-        if not self._in_buffer():
-            intercepted = True
-        else:
+        if not intercepted:
             if self._get_buffer().endswith(self._tab_chars):
                 for i in range(len(self._tab_chars) - 1):
                     self.textCursor().deletePreviousChar()
@@ -132,11 +130,7 @@ class BaseConsole(QTextEdit):
         return True
 
     def handle_left_key(self, event):
-        intercepted = False
-
-        if not self._in_buffer():
-            intercepted = True
-
+        intercepted = self._cursor_offset() < 1
         return intercepted
 
     def handle_d_key(self, event):
@@ -165,9 +159,8 @@ class BaseConsole(QTextEdit):
         self.setTextCursor(cursor)
         self.ensureCursorVisible()
 
-    def _in_buffer(self):
-        buffer_pos = self.textCursor().position()
-        return buffer_pos > self._prompt_pos
+    def _cursor_offset(self):
+        return self.textCursor().position() - self._prompt_pos
 
     def _insert_prompt(self, prompt, lf=False, keep_buffer=False):
         if keep_buffer:

--- a/pyqtconsole/interpreter.py
+++ b/pyqtconsole/interpreter.py
@@ -18,7 +18,7 @@ class PythonInterpreter(InteractiveConsole):
         self.stdin = stdin
         self.stdout = stdout
 
-        self._running = False
+        self._running = True
         self._last_input = ''
         self._more = False
         self._current_line = 0
@@ -151,7 +151,8 @@ class PythonInterpreter(InteractiveConsole):
             self._rep_line(line)
 
     def exit(self):
-        self.stdin.write('exit\n')
+        if self._running:
+            self.stdin.write('exit\n')
 
     def set_buffer(self, _buffer):
         self._current_eval_buffer = _buffer.strip('\n')


### PR DESCRIPTION
Hi,

this PR fixes

- an infinite recursion that can arise when exiting the console
- the inability to insert text at the beginning of the prompt line
- unexpected cursor movement to end of line when pressing home/left keys
- loopholes that allowed the user to edit text outside the prompt region

For the last point, I had to set control to readonly, which removes a few non-essential but nice-to-have editting features such as Ctrl+Z/Ctrl+V/Ctrl+backspace. I will likely add these in a followup PR.

Best, Thomas