### PR TITLE
Reenable pasting by Ctrl-V or middle-mouse

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -76,8 +76,7 @@ class BaseConsole(QTextEdit):
 
     def insertFromMimeData(self, mime_data):
         if mime_data and mime_data.hasText():
-            self._keep_cursor_in_buffer()
-            self.evaluate_buffer(mime_data.text(), echo_lines = True)
+            self.insert_text(mime_data.text())
 
     def mousePressEvent(self, event):
         if event.button() == Qt.MiddleButton:
@@ -255,6 +254,20 @@ class BaseConsole(QTextEdit):
             self._copy_buffer = ''
 
     # Abstract
+    def insert_text(self, text):
+        self._keep_cursor_in_buffer()
+        text = '\n'.join([
+            self._fix_line(line)
+            for line in text.splitlines()])
+        self.insertPlainText(text)
+
+    def _fix_line(self, line):
+        # Remove the any remaining more prompt, to make it easier
+        # to copy/paste within the interpreter.
+        if line.startswith(self.interpreter._morep):
+            line = line[len(self.interpreter._morep):]
+        return line
+
     def exit(self):
         self.stdin.write('EOF\n')
 
@@ -263,9 +276,6 @@ class BaseConsole(QTextEdit):
             self.window().close()
 
     # Abstract
-    def evaluate_buffer(self, _buffer, echo_lines = False):
-        print(_buffer)
-
     def set_tab(self, chars):
         self._tab_chars = chars
 
@@ -304,13 +314,6 @@ class PythonConsole(BaseConsole):
     def closeEvent(self, event):
         self.exit()
         event.accept()
-
-    def evaluate_buffer(self, _buffer, echo_lines = False):
-        self.interpreter.set_buffer(_buffer)
-        if echo_lines:
-            self.stdin.write('%%eval_lines\n')
-        else:
-            self.stdin.write('%%eval_buffer\n')
 
     def get_completions(self, line):
         script = jedi.Interpreter(line, [self.interpreter.local_ns])


### PR DESCRIPTION
Reenable part of the features that I removed by setting the text control to readonly mode.

This also fixes an annoying behaviour of insertFromMimeData (which was already broken before any of my changes): whenever you pasted, it would immediately evaluate the pasted text (and it alone) instead of inserting it into the current buffer. This is now changed to insert into the current edit field.

The behaviour is still quirky for multiline strings, but I already have a somewhat larger change in mind that will fully resolve this issue (although it will probably require a new major version and some API breakage).

This PR is based on the cleanup branch and therefore best merged after the cleanup PR.

Best, Thomas

**Edit:** Also has some merge conflicts with the fixes branch that I can resolve once that one is merged.