### PR TITLE
Fix TypeError during compilation on py 3.8

### DIFF
--- a/pyqtconsole/interpreter.py
+++ b/pyqtconsole/interpreter.py
@@ -94,7 +94,10 @@ def compile_single_node(node, filename):
     if mode == 'eval':
         root = ast.Expression(node.value)
     else:
-        root = ast.Module([node])
+        if sys.version_info >= (3, 8):
+            root = ast.Module([node], type_ignores=[])
+        else:
+            root = ast.Module([node])
     return (compile(root, filename, mode), mode)
 
 


### PR DESCRIPTION
Apparently, in py 3.8 ast.Module has acquired a new required argument… see:

https://bugs.python.org/issue35894