### PR TITLE
Userspecified colors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,32 @@ Embedding
   consideration (at least to some extent) for longer running processes. The
   best method if you want to use pyQtgraph, Matplotlib, PyMca or similar.
 
+Customizing syntax highlighting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The coloring of the syntax highlighting can be customized by passing a
+``formats`` dictionary to the ``PythonConsole`` constructer. This dictionary
+must be shaped as follows:
+
+.. code-block:: python
+
+    import pyqtconsole.highlighter as hl
+    console = PythonConsole(formats={
+        'keyword':    hl.format('blue', 'bold'),
+        'operator':   hl.format('red'),
+        'brace':      hl.format('darkGray'),
+        'defclass':   hl.format('black', 'bold'),
+        'string':     hl.format('magenta'),
+        'string2':    hl.format('darkMagenta'),
+        'comment':    hl.format('darkGreen', 'italic'),
+        'self':       hl.format('black', 'italic'),
+        'numbers':    hl.format('brown'),
+        'inprompt':   hl.format('darkBlue', 'bold'),
+        'outprompt':  hl.format('darkRed', 'bold'),
+    })
+
+All keys are optional and default to the value shown above if left unspecified.
+
 Credits
 ~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -58,9 +58,6 @@ Embedding
   consideration (at least to some extent) for longer running processes. The
   best method if you want to use pyQtgraph, Matplotlib, PyMca or similar.
 
-* *trollius (asyncio)* - Runs the interpreter in a asyncio coroutine
-  `_trollius.py`_. Still experimental
-
 Credits
 ~~~~~~~
 

--- a/examples/inuithread.py
+++ b/examples/inuithread.py
@@ -4,6 +4,7 @@ import sys
 
 from pyqtconsole.qt.QtWidgets import QApplication
 from pyqtconsole.console import PythonConsole
+from pyqtconsole.highlighter import format
 
 
 def greet():
@@ -13,7 +14,9 @@ def greet():
 if __name__ == '__main__':
     app = QApplication([])
 
-    console = PythonConsole()
+    console = PythonConsole(formats={
+        'keyword': format('darkBlue', 'bold')
+    })
     console.push_local_ns('greet', greet)
     console.show()
 

--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -34,12 +34,12 @@ class BaseConsole(QFrame):
 
     input_applied_signal = Signal(str)
 
-    def __init__(self, parent = None):
+    def __init__(self, parent=None, formats=None):
         super(BaseConsole, self).__init__(parent)
 
         self.edit = edit = InputArea()
         self.pbar = pbar = PromptArea(
-            edit, self._get_prompt_text, PromptHighlighter())
+            edit, self._get_prompt_text, PromptHighlighter(formats=formats))
 
         layout = QHBoxLayout()
         layout.addWidget(pbar)
@@ -543,9 +543,9 @@ class PythonConsole(BaseConsole):
 
     """Interactive python GUI console."""
 
-    def __init__(self, parent=None, locals=None):
-        super(PythonConsole, self).__init__(parent)
-        self.highlighter = PythonHighlighter(self.edit.document())
+    def __init__(self, parent=None, locals=None, formats=None):
+        super(PythonConsole, self).__init__(parent, formats=formats)
+        self.highlighter = PythonHighlighter(self.edit.document(), formats=formats)
         self.interpreter = PythonInterpreter(self.stdin, self.stdout, locals=locals)
         self.interpreter.done_signal.connect(self._finish_command)
         self.interpreter.exit_signal.connect(self.exit)

--- a/pyqtconsole/highlighter.py
+++ b/pyqtconsole/highlighter.py
@@ -38,13 +38,14 @@ STYLES = {
 
 class PromptHighlighter(object):
 
-    def __init__(self):
+    def __init__(self, formats=None):
+        self.styles = styles = dict(STYLES, **formats)
         self.rules = [
             # Match the prompt incase of a console
-            (QRegExp(r'IN[^\:]*'), 0, STYLES['inprompt']),
-            (QRegExp(r'OUT[^\:]*'), 0, STYLES['outprompt']),
+            (QRegExp(r'IN[^\:]*'), 0, styles['inprompt']),
+            (QRegExp(r'OUT[^\:]*'), 0, styles['outprompt']),
             # Numeric literals
-            (QRegExp(r'\b[+-]?[0-9]+\b'), 0, STYLES['numbers']),
+            (QRegExp(r'\b[+-]?[0-9]+\b'), 0, styles['numbers']),
         ]
 
     def highlight(self, text):
@@ -63,19 +64,21 @@ class PythonHighlighter(QSyntaxHighlighter):
     # Python keywords
     keywords = keyword.kwlist
 
-    def __init__(self, document):
+    def __init__(self, document, formats=None):
         QSyntaxHighlighter.__init__(self, document)
+
+        self.styles = styles = dict(STYLES, **formats)
 
         # Multi-line strings (expression, flag, style)
         # FIXME: The triple-quotes in these two lines will mess up the
         # syntax highlighting from this point onward
-        self.tri_single = (QRegExp("'''"), 1, STYLES['string2'])
-        self.tri_double = (QRegExp('"""'), 2, STYLES['string2'])
+        self.tri_single = (QRegExp("'''"), 1, styles['string2'])
+        self.tri_double = (QRegExp('"""'), 2, styles['string2'])
 
         rules = []
 
         # Keyword, operator, and brace rules
-        rules += [(r'\b%s\b' % w, 0, STYLES['keyword'])
+        rules += [(r'\b%s\b' % w, 0, styles['keyword'])
             for w in PythonHighlighter.keywords]
 
         # All other rules
@@ -84,22 +87,22 @@ class PythonHighlighter(QSyntaxHighlighter):
             #(r'\bself\b', 0, STYLES['self']),
 
             # Double-quoted string, possibly containing escape sequences
-            (r'"[^"\\]*(\\.[^"\\]*)*"', 0, STYLES['string']),
+            (r'"[^"\\]*(\\.[^"\\]*)*"', 0, styles['string']),
             # Single-quoted string, possibly containing escape sequences
-            (r"'[^'\\]*(\\.[^'\\]*)*'", 0, STYLES['string']),
+            (r"'[^'\\]*(\\.[^'\\]*)*'", 0, styles['string']),
 
             # 'def' followed by an identifier
-            (r'\bdef\b\s*(\w+)', 1, STYLES['defclass']),
+            (r'\bdef\b\s*(\w+)', 1, styles['defclass']),
             # 'class' followed by an identifier
-            (r'\bclass\b\s*(\w+)', 1, STYLES['defclass']),
+            (r'\bclass\b\s*(\w+)', 1, styles['defclass']),
 
             # From '#' until a newline
-            (r'#[^\n]*', 0, STYLES['comment']),
+            (r'#[^\n]*', 0, styles['comment']),
 
             # Numeric literals
-            (r'\b[+-]?[0-9]+[lL]?\b', 0, STYLES['numbers']),
-            (r'\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\b', 0, STYLES['numbers']),
-            (r'\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b', 0, STYLES['numbers']),
+            (r'\b[+-]?[0-9]+[lL]?\b', 0, styles['numbers']),
+            (r'\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\b', 0, styles['numbers']),
+            (r'\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b', 0, styles['numbers']),
         ]
 
         # Build a QRegExp for each pattern


### PR DESCRIPTION
Allow user to override syntax highlighting color preferences, as suggested in #29.

Resolves #29

For now this requires that the user uses the `pyqtconsole.highlighter.format()` function as this requires the least additional logic on our side. If it turns out to be convenient, we could later add the ability to recognize plain strings directly etc.

Note that I'm somewhat unhappy with the name of the argument (`formats`), so if you have a better suggestion, I will adapt.

Best, Thomas