### PR TITLE
Fix crash when closing the interpreter window of the threaded example

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -591,6 +591,7 @@ class PythonConsole(BaseConsole):
         """Exit interpreter."""
         if self._thread:
             self._thread.exit()
+            self._thread.wait()
             self._thread = None
         self._close()
 


### PR DESCRIPTION
The application would crash with the following message on Ubuntu:
QThread: Destroyed while thread is still running
Aborted (core dumped)

This will wait until the thread is finished before destroying it