### PR TITLE
Close the thread in the hideEvent() callback and simplify exit()

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -522,15 +522,6 @@ class BaseConsole(QFrame):
             block = cursor.blockNumber() + 1
             del self._prompt_doc[block:block+num_lines]
 
-    def closeEvent(self, event):
-        """Exit interpreter when we're closing."""
-        self.exit()
-        event.accept()
-
-    def _close(self):
-        if self.window().isVisible():
-            self.window().close()
-
     def set_tab(self, chars):
         self._tab_chars = chars
 
@@ -587,13 +578,15 @@ class PythonConsole(BaseConsole):
     def _run_source(self, source):
         return self.interpreter.runsource(source, symbol='multi')
 
-    def exit(self):
-        """Exit interpreter."""
+    def hideEvent(self, _event):
         if self._thread:
             self._thread.exit()
             self._thread.wait()
             self._thread = None
-        self._close()
+
+    def exit(self):
+        """Exit interpreter."""
+        self.close()
 
     def get_completions(self, line):
         """Get completions. Used by the ``autocomplete`` extension."""


### PR DESCRIPTION
Doing the thread closure in `hideEvent()` ensures that the thread is stopped when you close the window via the window manager and using `exit()` in the interpreter.

Using the immediate close makes the widget more compatible when embedded in another application. The original code would close the entire app instead of just closing the interpreter widget.