### PR TITLE
interpreter: Disable excepthook on displaying exception

### DIFF
--- a/pyqtconsole/interpreter.py
+++ b/pyqtconsole/interpreter.py
@@ -40,7 +40,7 @@ class PythonInterpreter(QObject, InteractiveInterpreter):
         # are running. Same thing for the except hook, we don't know what the
         # user are doing in it.
         try:
-            with redirected_io(self.stdout), disabled_excepthook():
+            with redirected_io(self.stdout):
                 for code, mode in codes:
                     if mode == 'eval':
                         result = eval(code, self.locals)
@@ -64,10 +64,12 @@ class PythonInterpreter(QObject, InteractiveInterpreter):
         if type_ == KeyboardInterrupt:
             self.stdout.write('KeyboardInterrupt\n')
         else:
-            InteractiveInterpreter.showtraceback(self)
+            with disabled_excepthook():
+                InteractiveInterpreter.showtraceback(self)
 
     def showsyntaxerror(self, filename):
-        InteractiveInterpreter.showsyntaxerror(self, filename)
+        with disabled_excepthook():
+            InteractiveInterpreter.showsyntaxerror(self, filename)
         self.done_signal.emit(False, None)
 
 

--- a/pyqtconsole/interpreter.py
+++ b/pyqtconsole/interpreter.py
@@ -68,6 +68,8 @@ class PythonInterpreter(QObject, InteractiveInterpreter):
                 InteractiveInterpreter.showtraceback(self)
 
     def showsyntaxerror(self, filename):
+        self.stdout.write('\n')
+
         with disabled_excepthook():
             InteractiveInterpreter.showsyntaxerror(self, filename)
         self.done_signal.emit(False, None)


### PR DESCRIPTION
Hey, I'm looking to see if it's viable to implement this pyqtconsole in [Orange](https://github.com/biolab/orange3), to replace our current Python Script widget.

One of the walls I hit was that our excepthook was picking up exceptions thrown in the console. This change fixes the problem in my particular use case. Might also fix #46. 