### PR TITLE
Changed to new jedi complete method

### DIFF
--- a/pyqtconsole/console.py
+++ b/pyqtconsole/console.py
@@ -600,7 +600,14 @@ class PythonConsole(BaseConsole):
     def get_completions(self, line):
         """Get completions. Used by the ``autocomplete`` extension."""
         script = jedi.Interpreter(line, [self.interpreter.locals])
-        return [comp.name for comp in script.completions()]
+
+        try:
+            comps = script.complete()
+        except AttributeError:
+            # Jedi < 0.16.0 named the method differently
+            comps = script.completions()
+
+        return [comp.name for comp in comps]
 
     def push_local_ns(self, name, value):
         """Set a variable in the local namespace."""


### PR DESCRIPTION
Fixes #59 

The try-catch might not be necessary, since the `complete()` method has been present since jedi v0.16.0, from January 2020.