### PR TITLE
Add Github actions for tests and deployment to PyPi, bumped version to 1.2.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy-pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: python
+        uses: actions/setup-python@v1
+        with:
+            python-version: "3.10"
+      - name: Build
+        run: |
+          pip install wheel
+          python setup.py bdist_wheel
+      - name: Install pypa/build
+        run: |
+          pip install wheel
+          pip install build
+      - name: Build a wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish distribution package to PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: ${{ secrets.pypi_user }}
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Unittests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    strategy:
+        fail-fast: false
+        matrix:
+            python-version: ["3.7", "3.8", "3.9", "3.10"]
+            os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: python
+        uses: actions/setup-python@v1
+        with:
+            python-version: ${{ matrix.python-version }}
+      - name: install
+        run: |
+          pip install .
+          pip install pytest
+      - name: test
+        run: pytest

--- a/pyqtconsole/__init__.py
+++ b/pyqtconsole/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 __description__ = \
     'Lightweight python console, easy to embed into Qt applications'
 __author__ = 'Marcus Oskarsson'


### PR DESCRIPTION
in order to get a new release here's a little pr:

- bump the version to 1.2.2 in the source
- add tests to gh-actions
- add deploy job to gh-actions
  * requires `pypi_user` and `pypi_password` secrets to be set
  * uploads new wheels/sources on git-tags