### PR TITLE
Updated PyPi publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,13 @@ jobs:
     needs: [build_and_test, linting]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v7
         with:
           name: dist ubuntu-latest 3.13
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Resolves #92 
- #92 

Based on top of #96 

- [x] Add trusted publisher before merging
- [x] Merge #96 first
- [x] Change from `testpypi` back to `pypi`
